### PR TITLE
fix for extension hanging on analysis of non-'.spthy' files

### DIFF
--- a/src/features/syntax_errors.ts
+++ b/src/features/syntax_errors.ts
@@ -44,18 +44,26 @@ I tried to personnalize error messages according to the different cases
 I did the most common ones*/
 export async function detect_errors(editeur: vscode.TextEditor): Promise<Parser.SyntaxNode|void> {
     let editor = editeur;
+    
+    if (!editor) {
+        return;
+    }
+
+    // fail-save to prevent analysis of non-tamarin files
+    const languageId = editor.document.languageId
+    if (!(languageId === 'tamarin')){
+        return;
+    }
+
     await Parser.init();
     const parser = new Parser();
     const parserPath = path.join(__dirname + '../../../', 'src', 'grammar', 'parser-tamarin.wasm'); //Charge la grammaire tree-sitter pour parser
     const Tamarin =  await Parser.Language.load(parserPath);
     parser.setLanguage(Tamarin);
-    if (!editor) {
-        return;
-    }
+    
     let diags: vscode.Diagnostic[] = [];
     let text = editor.document.getText();
     const tree =  parser.parse(text);
-
     
     function build_error_display(node : Parser.SyntaxNode, editeur: vscode.TextEditor, message : string){
         let start = node.startIndex;


### PR DESCRIPTION
I had an issue with the Tamarin extension trying to analyze non-Tamarin files, and depending on the file type hanging indefinitely (and triggering VS-Code resource consumption warnings), or showing wrong error messages.

I don't really do VS extension development, so I was unsure how to properly test the (albeit miniscule) changes for general impact/compatibility outside of running "npm test". 

For the original issue, I did successfully test locally.

Feel free to move the language check upwards in the call trace - I did not want to understand the entire extension (and how VSCode extensions might get invoked) and just added a "fail-save" in the actual analysis function.