### PR TITLE
fix on opening non spthy and splib files

### DIFF
--- a/src/features/syntax_errors.ts
+++ b/src/features/syntax_errors.ts
@@ -207,6 +207,9 @@ export function display_syntax_errors(context: vscode.ExtensionContext): void {
 
     const changed_content = vscode.workspace.onDidChangeTextDocument((event) => {
         vscode.window.visibleTextEditors.forEach(async (editor) => {
+            if (editor.document.languageId !== 'tamarin') {
+               return;
+            }
             if (editor.document === event.document) {
                 const tree = await detect_errors(editor);
                 if (tree) {


### PR DESCRIPTION
Here is a fix on plugin opening non tamarin files, the fix might not work on files recognised as tamarin files that are not tamarin files