### PR TITLE
Issue 7 bugfix

### DIFF
--- a/src/features/wellformedness_checks.ts
+++ b/src/features/wellformedness_checks.ts
@@ -498,8 +498,8 @@ function check_macro_not_in_equation(symbol_table : TamarinSymbolTable, editor: 
 function check_equality_types(symbol_table : TamarinSymbolTable, editor: vscode.TextEditor, diags: vscode.Diagnostic[]){
     for(let i =0; i < symbol_table.getSymbols().length; i++){
         let symbol= symbol_table.getSymbol(i);
-        if(symbol.context.grammarType === 'temp_var_eq' ||symbol.context.grammarType === 'term_eq'){
-            i++;
+        if(symbol.context.grammarType === 'temp_var_eq' ||symbol.context.grammarType === 'term_eq'){ //both nodes are used in equalites
+            i++; //only the left side of the equation needs to be checked
             let type = symbol.type;
             let name = symbol.name;
             let declaration = symbol.declaration;
@@ -662,7 +662,7 @@ export function checks_with_table(symbol_table : TamarinSymbolTable, editor: vsc
     }
 
 
-    //check_equality_types(symbol_table, editor, diags);
+    check_equality_types(symbol_table, editor, diags);
     check_variables_type_is_consistent_inside_a_rule(symbol_table, editor, diags);
     check_variable_is_defined_in_premise(symbol_table, editor, diags);
     check_action_fact(symbol_table, editor, diags);

--- a/src/symbol_table/create_symbol_table.ts
+++ b/src/symbol_table/create_symbol_table.ts
@@ -215,6 +215,7 @@ const ExistingBuiltIns : string[] =
     'bilinear-pairing',
     'xor',
     'default',
+    'natural-numbers'
 ]
 
 //First the name and then the arity also mind the order above (inv and 1 are diffie-hellman functions etc …)
@@ -374,48 +375,6 @@ class SymbolTableVisitor{
             else if( child?.grammarType === DeclarationType.Rule_let_block){
                 this.register_vars_rule(child, DeclarationType.PRVariable, editor, root)
             }
-            /*else if (child?.grammarType === 'include'){
-                const fileName = getName(child.child(2), editor);
-                const currentFileDir = path.dirname(editor.document.uri.fsPath);
-                const filePath = path.join(currentFileDir, fileName);
-                const includedFileUri = vscode.Uri.file(filePath);
-                const includedDocument = await vscode.workspace.openTextDocument(includedFileUri);
-                //Fake editor containing the right document to manage the includes 
-                const includedEditor = {
-                    document: includedDocument,
-                    selection: new vscode.Selection(0, 0, 0, 0),
-                    selections: [new vscode.Selection(0, 0, 0, 0)], // Example selections
-                    options: { tabSize: 4, insertSpaces: true }, // Example options
-                    viewColumn: vscode.ViewColumn.One, // Example view column
-                    visibleRanges: [new vscode.Range(0, 0, 0, 0)], // Example visible ranges
-                    edit(callback: (editBuilder: vscode.TextEditorEdit) => void, options?: { undoStopBefore: boolean; undoStopAfter: boolean }): Thenable<boolean> {
-                        throw new Error('Method not implemented.');
-                    },
-                    insertSnippet(snippet: vscode.SnippetString | vscode.SnippetString[], location?: vscode.Range | vscode.Position | vscode.Position[], options?: { undoStopBefore: boolean; undoStopAfter: boolean }): Thenable<boolean> {
-                        throw new Error('Method not implemented.');
-                    },
-                    setDecorations(decorationType: vscode.TextEditorDecorationType, rangesOrOptions: vscode.Range[] | vscode.DecorationOptions[]): void {
-                        throw new Error('Method not implemented.');
-                    },
-                    revealRange(range: vscode.Range, revealType?: vscode.TextEditorRevealType): void {
-                        throw new Error('Method not implemented.');
-                    },
-                    show(column?: vscode.ViewColumn): void {
-                        throw new Error('Method not implemented.');
-                    },
-                    hide(): void {
-                        throw new Error('Method not implemented.');
-                    }
-                };
-                
-                if (includedEditor) {
-                    const includedFileContent = await vscode.workspace.fs.readFile(includedFileUri);
-                    const includedFileText = includedFileContent.toString();
-
-                    const tree_root = await parseText(includedFileText);
-                    await this.visit(tree_root, includedEditor, diags);
-                }
-            }*/
             else{
                 if(child !== null){
                     await this.visit(child, editor, diags);
@@ -476,7 +435,15 @@ class SymbolTableVisitor{
         let vars: Parser.SyntaxNode[] = find_variables(node);
         for(let k = 0; k < vars.length; k++){
             let context: Parser.SyntaxNode = vars[k];
-            while(context.grammarType !== DeclarationType.NF  && context.grammarType !== 'conjunction' && context.grammarType !== 'disjunction' && (context.grammarType !== DeclarationType.Lemma && context.grammarType !== DeclarationType.Restriction && context.grammarType !== 'diff_lemma') ){
+            while(context.grammarType !== DeclarationType.NF && 
+                context.grammarType !== 'conjunction' && 
+                context.grammarType !== 'disjunction' && 
+                context.grammarType !== DeclarationType.Lemma && 
+                context.grammarType !== DeclarationType.Restriction && 
+                context.grammarType !== 'diff_lemma' &&
+                context.grammarType !== 'term_eq' &&
+                context.grammarType !== 'temp_var_eq'
+                ){
                 if(context.parent){
                     context = context.parent;
                 }

--- a/src/symbol_table/create_symbol_table.ts
+++ b/src/symbol_table/create_symbol_table.ts
@@ -441,8 +441,8 @@ class SymbolTableVisitor{
                 context.grammarType !== DeclarationType.Lemma && 
                 context.grammarType !== DeclarationType.Restriction && 
                 context.grammarType !== 'diff_lemma' &&
-                context.grammarType !== 'term_eq' &&
-                context.grammarType !== 'temp_var_eq'
+                context.grammarType !== 'term_eq' && //node used in equalities
+                context.grammarType !== 'temp_var_eq' //node used in equalities between temporal variables
                 ){
                 if(context.parent){
                     context = context.parent;


### PR DESCRIPTION
One method has been added to wellformedness_checks to correctly throw errors when variables are incorrectly used in equalities, only the left variable is checked according to tamarin semantic rules. 