### PR TITLE
Add automatic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.16.0
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}


### PR DESCRIPTION
Hi all,

I noticed a rather odd behavior when using the extension. I’ve split my model into several .splib files, and in the current released version on both marketplaces (Open VSX Registry and Visual Studio Code Marketplace), all .splib files are underlined in red, indicating an issue with the Tree-sitter grammar.

After investigating, I compiled the extension locally and the issue disappeared. I spent quite some time debugging and comparing dependencies between the released and self-compiled builds, and it turns out that the latest GitHub releases (2.1.0) don’t correspond to a specific version in the marketplace (the latest one is 1.2.0). In other words, the current version on GitHub no longer has this problem.

To prevent version mismatches like this in the future, I’d like to propose introducing an automated release workflow for new tags in this repository.

For this workflow, the following repository secrets will need to be added:
- `OPEN_VSX_TOKEN`
- `VS_MARKETPLACE_TOKEN`

TL;DR: The version in the marketplaces differs from the version mentioned in the current GitHub release. An automated release workflow would prevent this.

Let me know what you think!

Best regards,
Nik